### PR TITLE
Fix output file handling for components that contain slashes

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,11 @@ runs:
       shell: bash
       run: |
         OUTPUT_FILE="${{ inputs.stack }}-${{ inputs.component }}.json"
+
+        # Since a component name may contain a slash, we need to create the directories for the output file
+	mkdir -p "$(dirname ${OUTPUT_FILE})"
+
+	# Extract the settings value from the component's stack configuration
         atmos describe component \
           ${{ inputs.component }} \
           -s ${{ inputs.stack }} \

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,9 @@ runs:
         OUTPUT_FILE="${{ inputs.stack }}-${{ inputs.component }}.json"
 
         # Since a component name may contain a slash, we need to create the directories for the output file
-	mkdir -p "$(dirname ${OUTPUT_FILE})"
+        mkdir -p "$(dirname ${OUTPUT_FILE})"
 
-	# Extract the settings value from the component's stack configuration
+        # Extract the settings value from the component's stack configuration
         atmos describe component \
           ${{ inputs.component }} \
           -s ${{ inputs.stack }} \

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
     - id: settings
       shell: bash
       run: |
-        OUTPUT_FILE="$(echo ${{ inputs.stack }}-${{ inputs.component }}.json | tr / _)"
+        OUTPUT_FILE="$(tr / _ <<<${{ inputs.stack }}-${{ inputs.component }}.json)"
 
         # Extract the settings value from the component's stack configuration
         atmos describe component \

--- a/action.yml
+++ b/action.yml
@@ -24,10 +24,7 @@ runs:
     - id: settings
       shell: bash
       run: |
-        OUTPUT_FILE="${{ inputs.stack }}-${{ inputs.component }}.json"
-
-        # Since a component name may contain a slash, we need to create the directories for the output file
-        mkdir -p "$(dirname ${OUTPUT_FILE})"
+        OUTPUT_FILE="$(echo ${{ inputs.stack }}-${{ inputs.component }}.json | tr / _)"
 
         # Extract the settings value from the component's stack configuration
         atmos describe component \


### PR DESCRIPTION
## what
* Slash slashes in the path

## why
* Components may contain slashes (e.g. `eks/cluster`), which will cause redirection to the `$OUTPUT_FILE` to fail if the directory does not exist.
* 
![CleanShot 2023-09-14 at 15 30 57](https://github.com/cloudposse/github-action-atmos-get-setting/assets/52489/069efe42-8660-4c03-a42a-e67721cc6efb)
