### PR TITLE
Get any info from atmos describe component

### DIFF
--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           component: foo
           stack: core-ue1-dev
-          settings-path: level1.level2.level3.secrets-arn
+          settings-path: settings.level1.level2.level3.secrets-arn
 
       - uses: ./
         id: derived

--- a/.github/workflows/test-positive.yml
+++ b/.github/workflows/test-positive.yml
@@ -37,14 +37,14 @@ jobs:
         with:
           component: derived
           stack: core-ue1-dev
-          settings-path: level1.example
+          settings-path: settings.level1.example
 
       - uses: ./
         id: defaults
         with:
           component: test-defaults
           stack: core-ue1-dev
-          settings-path: level1.example
+          settings-path: settings.level1.example
 
   assert:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ components:
             secret-ids: ${{ steps.example.outputs.value }}
 ```
 
-## Migrate `v1` to `v2`
+## Migrating from `v1` to `v2`
 
 Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section..
 If you want the same behavior in `v2`  as in`v1`, you should add the `settings` prefix to the value of the `settings-path` variable.

--- a/README.md
+++ b/README.md
@@ -96,12 +96,39 @@ components:
           with:
             component: foo
             stack: core-ue1-dev
-            settings-path: secrets-arn
+            settings-path: settings.secrets-arn
 
         - name: Set ENV Vars with AWS Secrets Manager Secret
           uses: aws-actions/aws-secretsmanager-get-secrets@v1
           with:
             secret-ids: ${{ steps.example.outputs.value }}
+```
+
+## Migrate `v0` to `v1`
+
+Starting from `v1` the action do not restrict component config just to `settings` section.
+If you want `v1` having the same behaviour as `v0` you should add `settings` in `settings-path` variable.
+
+```yaml
+  - name: Get Atmos Setting for Secret ARN
+    uses: cloudposse/github-action-atmos-get-setting@v1
+    id: example
+    with:
+      component: foo
+      stack: core-ue1-dev
+      settings-path: settings.secrets-arn  
+```
+
+same behaviour as
+
+```yaml
+  - name: Get Atmos Setting for Secret ARN
+    uses: cloudposse/github-action-atmos-get-setting@v0
+    id: example
+    with:
+      component: foo
+      stack: core-ue1-dev
+      settings-path: secrets-arn  
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -99,19 +99,19 @@ components:
             settings-path: settings.secrets-arn
 
         - name: Set ENV Vars with AWS Secrets Manager Secret
-          uses: aws-actions/aws-secretsmanager-get-secrets@v1
+          uses: aws-actions/aws-secretsmanager-get-secrets@v2
           with:
             secret-ids: ${{ steps.example.outputs.value }}
 ```
 
-## Migrate `v0` to `v1`
+## Migrate `v1` to `v2`
 
-Starting from `v1` the action do not restrict component config just to `settings` section.
-If you want `v1` having the same behaviour as `v0` you should add `settings` in `settings-path` variable.
+Starting from `v2` the action do not restrict component config just to `settings` section.
+If you want `v2` having the same behaviour as `v1` you should add `settings` in `settings-path` variable.
 
 ```yaml
   - name: Get Atmos Setting for Secret ARN
-    uses: cloudposse/github-action-atmos-get-setting@v1
+    uses: cloudposse/github-action-atmos-get-setting@v2
     id: example
     with:
       component: foo
@@ -123,7 +123,7 @@ same behaviour as
 
 ```yaml
   - name: Get Atmos Setting for Secret ARN
-    uses: cloudposse/github-action-atmos-get-setting@v0
+    uses: cloudposse/github-action-atmos-get-setting@v1
     id: example
     with:
       component: foo

--- a/README.md
+++ b/README.md
@@ -99,19 +99,19 @@ components:
             settings-path: settings.secrets-arn
 
         - name: Set ENV Vars with AWS Secrets Manager Secret
-          uses: aws-actions/aws-secretsmanager-get-secrets@v2
+          uses: aws-actions/aws-secretsmanager-get-secrets@v1
           with:
             secret-ids: ${{ steps.example.outputs.value }}
 ```
 
-## Migrating from `v1` to `v2`
+## Migrating from `v0` to `v1`
 
-Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section.
-If you want the same behavior in `v2`  as in`v1`, you should add the `settings.` prefix to the value of the `settings-path` variable.
-For example, in `v2` you would provide `settings.secrets-arn` as the value to the `settings-path`
+Starting from `v1` the action is no longer restricted to retrieving the component config from only the `settings` section.
+If you want the same behavior in `v1`  as in`v0`, you should add the `settings.` prefix to the value of the `settings-path` variable.
+For example, in `v1` you would provide `settings.secrets-arn` as the value to the `settings-path`
 ```yaml
   - name: Get Atmos Setting for Secret ARN
-    uses: cloudposse/github-action-atmos-get-setting@v2
+    uses: cloudposse/github-action-atmos-get-setting@v1
     id: example
     with:
       component: foo
@@ -119,11 +119,11 @@ For example, in `v2` you would provide `settings.secrets-arn` as the value to th
       settings-path: settings.secrets-arn  
 ```
 
-Which would provide the same output as passing only `secrets-arn` in `v1`
+Which would provide the same output as passing only `secrets-arn` in `v0`
 
 ```yaml
   - name: Get Atmos Setting for Secret ARN
-    uses: cloudposse/github-action-atmos-get-setting@v1
+    uses: cloudposse/github-action-atmos-get-setting@v0
     id: example
     with:
       component: foo

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ components:
 
 ## Migrate `v1` to `v2`
 
-Starting from `v2` the action do not restrict component config just to `settings` section.
-If you want `v2` having the same behaviour as `v1` you should add `settings` in `settings-path` variable.
+Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section..
+If you want the same behavior in `v2`  as in`v1`, you should add the `settings` prefix to the value of the `settings-path` variable.
 
 ```yaml
   - name: Get Atmos Setting for Secret ARN

--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ components:
 
 ## Migrating from `v1` to `v2`
 
-Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section..
-If you want the same behavior in `v2`  as in`v1`, you should add the `settings` prefix to the value of the `settings-path` variable.
-
+Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section.
+If you want the same behavior in `v2`  as in`v1`, you should add the `settings.` prefix to the value of the `settings-path` variable.
+For example, in `v2` you would provide `settings.secrets-arn` as the value to the `settings-path`
 ```yaml
   - name: Get Atmos Setting for Secret ARN
     uses: cloudposse/github-action-atmos-get-setting@v2
@@ -119,7 +119,7 @@ If you want the same behavior in `v2`  as in`v1`, you should add the `settings` 
       settings-path: settings.secrets-arn  
 ```
 
-same behaviour as
+Which would provide the same output as passing only `secrets-arn` in `v1`
 
 ```yaml
   - name: Get Atmos Setting for Secret ARN

--- a/README.yaml
+++ b/README.yaml
@@ -80,10 +80,10 @@ usage: |-
               secret-ids: ${{ steps.example.outputs.value }}
   ```
   
-  ## Migrate `v1` to `v2`
+  ## Migrating from `v1` to `v2`
   
-  Starting from `v2` the action do not restrict component config just to `settings` section.
-  If you want `v2` having the same behaviour as `v1` you should add `settings` in `settings-path` variable.
+  Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section..
+  If you want the same behavior in `v2`  as in`v1`, you should add the `settings` prefix to the value of the `settings-path` variable.
   
   ```yaml
     - name: Get Atmos Setting for Secret ARN

--- a/README.yaml
+++ b/README.yaml
@@ -75,19 +75,19 @@ usage: |-
               settings-path: settings.secrets-arn
 
           - name: Set ENV Vars with AWS Secrets Manager Secret
-            uses: aws-actions/aws-secretsmanager-get-secrets@v1
+            uses: aws-actions/aws-secretsmanager-get-secrets@v2
             with:
               secret-ids: ${{ steps.example.outputs.value }}
   ```
   
-  ## Migrate `v0` to `v1`
+  ## Migrate `v1` to `v2`
   
-  Starting from `v1` the action do not restrict component config just to `settings` section.
-  If you want `v1` having the same behaviour as `v0` you should add `settings` in `settings-path` variable.
+  Starting from `v2` the action do not restrict component config just to `settings` section.
+  If you want `v2` having the same behaviour as `v1` you should add `settings` in `settings-path` variable.
   
   ```yaml
     - name: Get Atmos Setting for Secret ARN
-      uses: cloudposse/github-action-atmos-get-setting@v1
+      uses: cloudposse/github-action-atmos-get-setting@v2
       id: example
       with:
         component: foo
@@ -99,7 +99,7 @@ usage: |-
   
   ```yaml
     - name: Get Atmos Setting for Secret ARN
-      uses: cloudposse/github-action-atmos-get-setting@v0
+      uses: cloudposse/github-action-atmos-get-setting@v1
       id: example
       with:
         component: foo

--- a/README.yaml
+++ b/README.yaml
@@ -72,13 +72,41 @@ usage: |-
             with:
               component: foo
               stack: core-ue1-dev
-              settings-path: secrets-arn
+              settings-path: settings.secrets-arn
 
           - name: Set ENV Vars with AWS Secrets Manager Secret
             uses: aws-actions/aws-secretsmanager-get-secrets@v1
             with:
               secret-ids: ${{ steps.example.outputs.value }}
   ```
+  
+  ## Migrate `v0` to `v1`
+  
+  Starting from `v1` the action do not restrict component config just to `settings` section.
+  If you want `v1` having the same behaviour as `v0` you should add `settings` in `settings-path` variable.
+  
+  ```yaml
+    - name: Get Atmos Setting for Secret ARN
+      uses: cloudposse/github-action-atmos-get-setting@v1
+      id: example
+      with:
+        component: foo
+        stack: core-ue1-dev
+        settings-path: settings.secrets-arn  
+  ```
+  
+  same behaviour as
+  
+  ```yaml
+    - name: Get Atmos Setting for Secret ARN
+      uses: cloudposse/github-action-atmos-get-setting@v0
+      id: example
+      with:
+        component: foo
+        stack: core-ue1-dev
+        settings-path: secrets-arn  
+  ```
+  
 
 include:
   - "docs/github-action.md"

--- a/README.yaml
+++ b/README.yaml
@@ -75,19 +75,19 @@ usage: |-
               settings-path: settings.secrets-arn
 
           - name: Set ENV Vars with AWS Secrets Manager Secret
-            uses: aws-actions/aws-secretsmanager-get-secrets@v2
+            uses: aws-actions/aws-secretsmanager-get-secrets@v1
             with:
               secret-ids: ${{ steps.example.outputs.value }}
   ```
   
-  ## Migrating from `v1` to `v2`
+  ## Migrating from `v0` to `v1`
   
-  Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section.
-  If you want the same behavior in `v2`  as in`v1`, you should add the `settings.` prefix to the value of the `settings-path` variable.
-  For example, in `v2` you would provide `settings.secrets-arn` as the value to the `settings-path`
+  Starting from `v1` the action is no longer restricted to retrieving the component config from only the `settings` section.
+  If you want the same behavior in `v1`  as in`v0`, you should add the `settings.` prefix to the value of the `settings-path` variable.
+  For example, in `v1` you would provide `settings.secrets-arn` as the value to the `settings-path`
   ```yaml
     - name: Get Atmos Setting for Secret ARN
-      uses: cloudposse/github-action-atmos-get-setting@v2
+      uses: cloudposse/github-action-atmos-get-setting@v1
       id: example
       with:
         component: foo
@@ -95,11 +95,11 @@ usage: |-
         settings-path: settings.secrets-arn  
   ```
   
-  Which would provide the same output as passing only `secrets-arn` in `v1`
+  Which would provide the same output as passing only `secrets-arn` in `v0`
   
   ```yaml
     - name: Get Atmos Setting for Secret ARN
-      uses: cloudposse/github-action-atmos-get-setting@v1
+      uses: cloudposse/github-action-atmos-get-setting@v0
       id: example
       with:
         component: foo

--- a/README.yaml
+++ b/README.yaml
@@ -82,9 +82,9 @@ usage: |-
   
   ## Migrating from `v1` to `v2`
   
-  Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section..
-  If you want the same behavior in `v2`  as in`v1`, you should add the `settings` prefix to the value of the `settings-path` variable.
-  
+  Starting from `v2` the action is no longer restricted to retrieving the component config from only the `settings` section.
+  If you want the same behavior in `v2`  as in`v1`, you should add the `settings.` prefix to the value of the `settings-path` variable.
+  For example, in `v2` you would provide `settings.secrets-arn` as the value to the `settings-path`
   ```yaml
     - name: Get Atmos Setting for Secret ARN
       uses: cloudposse/github-action-atmos-get-setting@v2
@@ -95,7 +95,7 @@ usage: |-
         settings-path: settings.secrets-arn  
   ```
   
-  same behaviour as
+  Which would provide the same output as passing only `secrets-arn` in `v1`
   
   ```yaml
     - name: Get Atmos Setting for Secret ARN

--- a/action.yml
+++ b/action.yml
@@ -32,5 +32,5 @@ runs:
           -s ${{ inputs.stack }} \
           --format json \
           --file "$OUTPUT_FILE" || echo '{}' > "$OUTPUT_FILE"
-        value=$(jq -rc --arg key ${{ inputs.settings-path }} '.settings | getpath($key | split("."))' "$OUTPUT_FILE")
+        value=$(jq -rc --arg key ${{ inputs.settings-path }} '. | getpath($key | split("."))' "$OUTPUT_FILE")
         echo "value=$value" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## what
* Remove restriction to `settings` section.

## Why
* To reuse this action for fetching `component_info.component_path` settings

## Migrating from `v0` to `v1`

Starting from `v1` the action is no longer restricted to retrieving the component config from only the `settings` section..
If you want the same behavior in `v1`  as in`v0`, you should add the `settings` prefix to the value of the `settings-path` variable.

```yaml
  - name: Get Atmos Setting for Secret ARN
    uses: cloudposse/github-action-atmos-get-setting@v1
    id: example
    with:
      component: foo
      stack: core-ue1-dev
      settings-path: settings.secrets-arn  
```

same behaviour as

```yaml
  - name: Get Atmos Setting for Secret ARN
    uses: cloudposse/github-action-atmos-get-setting@v0
    id: example
    with:
      component: foo
      stack: core-ue1-dev
      settings-path: secrets-arn  
```
