### PR TITLE
Fail on invalid config

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -31,6 +31,6 @@ runs:
           ${{ inputs.component }} \
           -s ${{ inputs.stack }} \
           --format json \
-          --file "$OUTPUT_FILE" || echo '{}' > "$OUTPUT_FILE"
+          --file "$OUTPUT_FILE"
         value=$(jq -rc --arg key ${{ inputs.settings-path }} '. | getpath($key | split("."))' "$OUTPUT_FILE")
         echo "value=$value" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## what
* remove `||` statement

## why
* Causes this action to succeed when in fact it has failed
